### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A comprehensive Model Context Protocol (MCP) server for the Starknet blockchain. This server provides AI agents with the ability to interact with Starknet networks, query blockchain data, manage wallets, and interact with smart contracts.
 
+<a href="https://glama.ai/mcp/servers/@mcpdotdirect/starknet-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mcpdotdirect/starknet-mcp-server/badge" alt="Starknet Server MCP server" />
+</a>
+
 ## 📋 Contents
 
 - [Overview](#-overview)


### PR DESCRIPTION
This PR adds a badge for the [Starknet MCP Server](https://glama.ai/mcp/servers/@mcpdotdirect/starknet-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mcpdotdirect/starknet-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mcpdotdirect/starknet-mcp-server/badge" alt="Starknet Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a clickable badge image linking to the MCP server page on glama.ai near the top of the README.
  - Minor formatting update in the license section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->